### PR TITLE
add globals option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Enable or disable the recursive directory mocha option
 
 Paths for run all specs
 
+* `:globals # default => []`
+
+Globals to ignore when performing global leak detection
+
 * `:mocha_bin`
 
 Specify the path to the jasmine-node binary that will execute your specs.

--- a/lib/guard/mocha_node.rb
+++ b/lib/guard/mocha_node.rb
@@ -12,11 +12,12 @@ module Guard
       :coffeescript     => true,
       :livescript       => false,
       :verbose          => true,
-      :reporter		=> "spec",
+      :reporter         => "spec",
       :color            => true,
       :recursive        => true,
       :require          => nil,
-      :paths_for_all_specs => %w(spec)
+      :paths_for_all_specs => %w(spec),
+      :globals          => []
     }
 
     autoload :Runner,    "guard/mocha_node/runner"

--- a/lib/guard/mocha_node/runner.rb
+++ b/lib/guard/mocha_node/runner.rb
@@ -71,6 +71,11 @@ module Guard
           options << "-C"
         end
 
+        if @options[:globals] and not @options[:globals].empty?
+          options << "--globals"
+          options << @options[:globals].join(',')
+        end
+
 	# puts "---- printing the options"
 	# puts options
         options

--- a/spec/lib/mocha_node_spec.rb
+++ b/spec/lib/mocha_node_spec.rb
@@ -57,11 +57,15 @@ describe Guard::MochaNode do
       end
 
       it "sets :require option to nil" do
-	guard.options[:require].should_not be
+        guard.options[:require].should_not be
       end
 
       it "sets :paths_for_all_specs  option to ['spec']" do
         guard.options[:paths_for_all_specs].should eql ['spec']
+      end
+
+      it "sets :globals option to []" do
+        guard.options[:globals].should eql []
       end
 
       it "is passing" do
@@ -87,7 +91,8 @@ describe Guard::MochaNode do
 																						  :color            => false,
 																						  :recursive        => false,
 																						  :require          => "should",
-																						  :paths_for_all_specs => %w(test)
+																						  :paths_for_all_specs => %w(test),
+                                              :globals          => ['Foo']
                                             }) }
 
       it "sets the path to mocha bin" do
@@ -132,6 +137,9 @@ describe Guard::MochaNode do
       end
       it "sets the :paths_for_all_specs option" do
         guard.options[:paths_for_all_specs].should eql ['test']
+      end
+      it "sets the :globals option" do
+        guard.options[:globals].should eql ['Foo']
       end
     end
   end

--- a/spec/lib/runner_spec.rb
+++ b/spec/lib/runner_spec.rb
@@ -108,6 +108,26 @@ describe Guard::MochaNode::Runner do
         end
       end
 
+      context "and globals option is set" do
+        it "passes the --globals option to mocha node" do
+          Open3.should_receive(:popen3) do |*args|
+	    args.should include("--globals", "Foo")
+            # ensure ordering
+            args[args.index("--globals") + 1].should eql("Foo")
+	  end
+          runner.run(some_paths, options.merge({ :globals => ['Foo']}))
+        end
+      end
+
+      context "and globals option is empty" do
+        it "does not pass the --globals option to mocha node" do
+          Open3.should_receive(:popen3) do |*args|
+	    args.should_not include "--globals"
+	  end
+          runner.run(some_paths, options.merge({ :globals => []}))
+        end
+      end
+
       context "and recursive option is true" do
         it "passes the --recursive option to mocha node" do
           Open3.should_receive(:popen3) do |*args|


### PR DESCRIPTION
Attached PR adds a `:globals => ['Global1', 'Global2', ...]` option that passes through to [Mocha's `--global` option](http://visionmedia.github.com/mocha/#globals-option).
