### PR TITLE
Output stdout immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Enable or disable the recursive directory mocha option
 
 Paths for run all specs
 
+* `:globals # default => []`
+
+Globals to ignore when performing global leak detection
+
 * `:mocha_bin`
 
 Specify the path to the jasmine-node binary that will execute your specs.

--- a/lib/guard/mocha_node.rb
+++ b/lib/guard/mocha_node.rb
@@ -12,11 +12,12 @@ module Guard
       :coffeescript     => true,
       :livescript       => false,
       :verbose          => true,
-      :reporter		=> "spec",
+      :reporter         => "spec",
       :color            => true,
       :recursive        => true,
       :require          => nil,
-      :paths_for_all_specs => %w(spec)
+      :paths_for_all_specs => %w(spec),
+      :globals          => []
     }
 
     autoload :Runner,    "guard/mocha_node/runner"

--- a/lib/guard/mocha_node/runner.rb
+++ b/lib/guard/mocha_node/runner.rb
@@ -71,6 +71,11 @@ module Guard
           options << "-C"
         end
 
+        if @options[:globals] and not @options[:globals].empty?
+          options << "--globals"
+          options << @options[:globals].join(',')
+        end
+
 	# puts "---- printing the options"
 	# puts options
         options

--- a/lib/guard/mocha_node/runner.rb
+++ b/lib/guard/mocha_node/runner.rb
@@ -76,6 +76,11 @@ module Guard
           options << @options[:globals].join(',')
         end
 
+        if @options[:reporter]
+          options << "--reporter"
+          options << @options[:reporter]
+        end
+
 	# puts "---- printing the options"
 	# puts options
         options

--- a/lib/guard/mocha_node/spec_state.rb
+++ b/lib/guard/mocha_node/spec_state.rb
@@ -20,9 +20,13 @@ module Guard
         @io = Runner.run(@run_paths, options)
         @stdout     = @io[STDOUT]
         @stderr     = @io[STDERR]
-        @exitstatus = @io[THREAD].value rescue ERROR_CODE
-        @stdout.lines { |line| print line if !line.strip.empty? }
+        # stream stdout immediately
+        until @stdout.eof?
+          line = @stdout.gets
+          print line if !line.strip.empty?
+        end
         @stderr.lines { |line| print line }
+        @exitstatus = @io[THREAD].value rescue ERROR_CODE
         close_io
         update_passed_and_fixed
         update_failing_paths

--- a/spec/lib/mocha_node_spec.rb
+++ b/spec/lib/mocha_node_spec.rb
@@ -57,11 +57,15 @@ describe Guard::MochaNode do
       end
 
       it "sets :require option to nil" do
-	guard.options[:require].should_not be
+        guard.options[:require].should_not be
       end
 
       it "sets :paths_for_all_specs  option to ['spec']" do
         guard.options[:paths_for_all_specs].should eql ['spec']
+      end
+
+      it "sets :globals option to []" do
+        guard.options[:globals].should eql []
       end
 
       it "is passing" do
@@ -87,7 +91,8 @@ describe Guard::MochaNode do
 																						  :color            => false,
 																						  :recursive        => false,
 																						  :require          => "should",
-																						  :paths_for_all_specs => %w(test)
+																						  :paths_for_all_specs => %w(test),
+                                              :globals          => ['Foo']
                                             }) }
 
       it "sets the path to mocha bin" do
@@ -132,6 +137,9 @@ describe Guard::MochaNode do
       end
       it "sets the :paths_for_all_specs option" do
         guard.options[:paths_for_all_specs].should eql ['test']
+      end
+      it "sets the :globals option" do
+        guard.options[:globals].should eql ['Foo']
       end
     end
   end

--- a/spec/lib/runner_spec.rb
+++ b/spec/lib/runner_spec.rb
@@ -108,6 +108,26 @@ describe Guard::MochaNode::Runner do
         end
       end
 
+      context "and globals option is set" do
+        it "passes the --globals option to mocha node" do
+          Open3.should_receive(:popen3) do |*args|
+	    args.should include("--globals", "Foo")
+            # ensure ordering
+            args[args.index("--globals") + 1].should eql("Foo")
+	  end
+          runner.run(some_paths, options.merge({ :globals => ['Foo']}))
+        end
+      end
+
+      context "and globals option is empty" do
+        it "does not pass the --globals option to mocha node" do
+          Open3.should_receive(:popen3) do |*args|
+	    args.should_not include "--globals"
+	  end
+          runner.run(some_paths, options.merge({ :globals => []}))
+        end
+      end
+
       context "and recursive option is true" do
         it "passes the --recursive option to mocha node" do
           Open3.should_receive(:popen3) do |*args|

--- a/spec/lib/runner_spec.rb
+++ b/spec/lib/runner_spec.rb
@@ -128,6 +128,26 @@ describe Guard::MochaNode::Runner do
         end
       end
 
+      context "and reporter option is set" do
+        it "passes the --reporter option to mocha node" do
+          Open3.should_receive(:popen3) do |*args|
+            args.should include("--reporter", "Foo")
+            # ensure ordering
+            args[args.index("--reporter") + 1].should eql("Foo")
+          end
+          runner.run(some_paths, options.merge({ :reporter => 'Foo' }))
+        end
+      end
+
+      context "and reporter option is not set" do
+        it "does not pass the --reporter option to mocha node" do
+          Open3.should_receive(:popen3) do |*args|
+            args.should_not include "--reporter"
+          end
+          runner.run(some_paths, options)
+        end
+      end
+
       context "and recursive option is true" do
         it "passes the --recursive option to mocha node" do
           Open3.should_receive(:popen3) do |*args|

--- a/spec/lib/spec_state_spec.rb
+++ b/spec/lib/spec_state_spec.rb
@@ -21,7 +21,7 @@ describe Guard::MochaNode::SpecState do
   describe "#update" do
     let(:io) { [
                 double("stdin",  :close => true),
-                double("stdout", :close => true, :lines => []),
+                double("stdout", :close => true, :lines => [], :eof? => true),
                 double("stderr", :close => true, :lines => []),
                 double("thread", :value => 0)
                ] }


### PR DESCRIPTION
Previously guard-mocha-node would buffer all output from the mocha process until the process completes, with this stdout is passed through immediately.
